### PR TITLE
Add Opik to vendors list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [Lumigo](https://lumigo.io)
 - [Metoro](https://metoro.io)
 - [New Relic](https://newrelic.com)
+- [Opik](https://www.comet.com/site/products/opik/)
 - [SigNoz](https://signoz.io/)
 - [Splunk](https://www.splunk.com)
 - [TelemetryHub](https://telemetryhub.com/)


### PR DESCRIPTION
## Summary
- Add [Opik](https://github.com/comet-ml/opik) to the Vendors list.

## Why
- Opik is an open-source LLM observability/tracing/evaluation platform and fits this list.

## Notes
- Followed the repository contribution guidelines and existing formatting.
