### PR TITLE
Add Manifest to Open Source distributed tracing solutions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,6 +178,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [OpenCensus](https://opencensus.io) - **Deprecated**
 - [Agent-SRE](https://github.com/imran-siddique/agent-sre) - AI-native SRE framework with OTel-compatible SLI/SLO metrics, chaos test spans, and canary deployment traces for AI agent observability
 - [Agent-Hypervisor](https://github.com/imran-siddique/agent-hypervisor) - Runtime supervisor for multi-agent systems with a structured event bus (40+ event types) that exports ring transitions, saga steps, and liability events as distributed traces
+- [Manifest](https://manifest.build) ([GitHub](https://github.com/mnfst/manifest)) - Open-source real-time cost observability for AI agents. OTLP-native, accepts standard OpenTelemetry signals via HTTP (JSON and Protobuf). Tracks tokens, costs, messages, and model usage. Self-hostable and privacy-focused.
 
 ### Vendors
 


### PR DESCRIPTION
## Summary

- Adds [Manifest](https://manifest.build) ([GitHub](https://github.com/mnfst/manifest)) to the **Open Source** section under **Distributed Tracing Solutions**
- Manifest is an open-source, OTLP-native real-time cost observability platform for AI agents
- It accepts standard OpenTelemetry signals via HTTP (JSON and Protobuf), tracks tokens, costs, messages, and model usage
- Self-hostable and privacy-focused, licensed under MIT

## Details

| Field | Value |
|-------|-------|
| Website | https://manifest.build |
| GitHub | https://github.com/mnfst/manifest |
| License | MIT |