### PR TITLE
Add Ingero - eBPF-based GPU observability with OTLP export

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -312,6 +312,7 @@ Refer from [OpenTelemetry Official Document](https://github.com/open-telemetry/o
 ### Agent
 An agent listens for spans, which it batches and sends to the Collector. The agent is meant to be placed on the same host as the instrumented application. This is typically accomplished by having a sidecar in container environments such as Kubernetes or running it as a DaemonSet (on each node).
 
+- [Ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent with OTLP export. Traces CUDA APIs and host kernel events via uprobes, exports to any OpenTelemetry-compatible backend.
 - [OpenTelemetry](https://opentelemetry.io/docs/collector/getting-started/)
 
 ### OTLP


### PR DESCRIPTION
## Summary

Adds [Ingero](https://github.com/ingero-io/ingero) to the **Agent** section.

Ingero is an open-source, eBPF-based GPU causal observability agent. It traces CUDA Runtime and Driver APIs via Linux kernel uprobes and host OS events (CPU scheduling, memory, process lifecycle) via kernel tracepoints, then exports telemetry to any OpenTelemetry-compatible backend via OTLP/HTTP.

Key OpenTelemetry-relevant features:
- Native OTLP/HTTP export (`--otlp` flag)
- Prometheus `/metrics` endpoint (`--prometheus` flag)
- Designed for production use as a DaemonSet on GPU nodes (<2% overhead)
- Single Go binary, zero external dependencies

Entry added in alphabetical order in the Agent section.