### PR TITLE
chore: update Agent Governance Toolkit URLs to microsoft/ org

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,8 +178,8 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [Sematext](https://sematext.com/)
 - [OpenTracing](https://opentracing.io) - **Deprecated**
 - [OpenCensus](https://opencensus.io) - **Deprecated**
-- [Agent-SRE](https://github.com/imran-siddique/agent-sre) - AI-native SRE framework with OTel-compatible SLI/SLO metrics, chaos test spans, and canary deployment traces for AI agent observability
-- [Agent-Hypervisor](https://github.com/imran-siddique/agent-hypervisor) - Runtime supervisor for multi-agent systems with a structured event bus (40+ event types) that exports ring transitions, saga steps, and liability events as distributed traces
+- [Agent-SRE](https://github.com/microsoft/agent-governance-toolkit/tree/main/packages/agent-sre) - AI-native SRE framework with OTel-compatible SLI/SLO metrics, chaos test spans, and canary deployment traces for AI agent observability
+- [Agent-Hypervisor](https://github.com/microsoft/agent-governance-toolkit/tree/main/packages/agent-runtime) - Runtime supervisor for multi-agent systems with a structured event bus (40+ event types) that exports ring transitions, saga steps, and liability events as distributed traces
 - [Manifest](https://manifest.build) ([GitHub](https://github.com/mnfst/manifest)) - Open-source real-time cost observability for AI agents. OTLP-native, accepts standard OpenTelemetry signals via HTTP (JSON and Protobuf). Tracks tokens, costs, messages, and model usage. Self-hostable and privacy-focused.
 
 ### Vendors


### PR DESCRIPTION
The Agent Governance Toolkit has moved to [microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit). This PR updates Agent-SRE and Agent-Hypervisor URLs to the new monorepo location.