### PR TITLE
Add AgentWatch to Distributed Tracing section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [OpenCensus](https://opencensus.io) - **Deprecated**
 - [Agent-SRE](https://github.com/imran-siddique/agent-sre) - AI-native SRE framework with OTel-compatible SLI/SLO metrics, chaos test spans, and canary deployment traces for AI agent observability
 - [Agent-Hypervisor](https://github.com/imran-siddique/agent-hypervisor) - Runtime supervisor for multi-agent systems with a structured event bus (40+ event types) that exports ring transitions, saga steps, and liability events as distributed traces
+- [AgentWatch](https://github.com/nicofains1/agentwatch) - Multi-agent fleet observability with cascade failure detection and forensic replay for AI agent systems.
 - [Manifest](https://manifest.build) ([GitHub](https://github.com/mnfst/manifest)) - Open-source real-time cost observability for AI agents. OTLP-native, accepts standard OpenTelemetry signals via HTTP (JSON and Protobuf). Tracks tokens, costs, messages, and model usage. Self-hostable and privacy-focused.
 
 ### Vendors


### PR DESCRIPTION
Adds [AgentWatch](https://github.com/nicofains1/agentwatch) to the Distributed Tracing / Open Source section.

AgentWatch provides multi-agent fleet observability with cascade failure detection and forensic replay. It correlates failures across agent chains that per-agent tracing tools miss.

- npm: @nicofains1/agentwatch
- 16 tests passing
- CLI: npx agentwatch dashboard|cascade|failures|alerts|replay

Ref: #32