### PR TITLE
Add traceAI by futureagi

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [Agent-SRE](https://github.com/imran-siddique/agent-sre) - AI-native SRE framework with OTel-compatible SLI/SLO metrics, chaos test spans, and canary deployment traces for AI agent observability
 - [Agent-Hypervisor](https://github.com/imran-siddique/agent-hypervisor) - Runtime supervisor for multi-agent systems with a structured event bus (40+ event types) that exports ring transitions, saga steps, and liability events as distributed traces
 - [Manifest](https://manifest.build) ([GitHub](https://github.com/mnfst/manifest)) - Open-source real-time cost observability for AI agents. OTLP-native, accepts standard OpenTelemetry signals via HTTP (JSON and Protobuf). Tracks tokens, costs, messages, and model usage. Self-hostable and privacy-focused.
-
+- [traceAI](https://github.com/future-agi/traceAI) - Open-source OpenTelemetry-native instrumentation framework for AI applications that auto-instruments 20+ LLM providers and agent frameworks, capturing prompts, tokens, latency, and errors with zero code changes.
 ### Vendors
 
 - [Aspecto](https://www.aspecto.io)


### PR DESCRIPTION
traceAI is an open-source OpenTelemetry-native instrumentation framework for AI applications, with auto-instrumentation for 20+ LLM providers and agent frameworks including OpenAI, Anthropic, LangChain, LlamaIndex, CrewAI, and Bedrock — capturing prompts, tokens, latency, and errors with zero code changes.