### PR TITLE
Add TraceVerde - GenAI/LLM auto-instrumentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -251,6 +251,9 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [Rust](https://opentelemetry.io/docs/instrumentation/rust/) - A language-specific implementation of OpenTelemetry in Rust.
 - [Swift](https://opentelemetry.io/docs/instrumentation/swift/) - A language-specific implementation of OpenTelemetry in Swift.
 
+### GenAI / LLM Instrumentation
+- [TraceVerde (genai-otel-instrument)](https://github.com/Mandark-droid/genai_otel_instrument) - Comprehensive OpenTelemetry auto-instrumentation for LLM/GenAI applications. Zero-code setup for 19+ LLM providers, 8 multi-agent frameworks, 20+ MCP tools with automatic cost tracking for 1,050+ models and GPU metrics.
+
 ### Vendors Distro
 Distributions and vendors who natively support OpenTelemetry in their commercial products.
 


### PR DESCRIPTION
## Summary

Adds [TraceVerde](https://github.com/Mandark-droid/genai_otel_instrument) under a new "GenAI / LLM Instrumentation" subsection in the OpenTelemetry Instrumentation section.

TraceVerde (`genai-otel-instrument`) is an Apache-2.0 licensed Python library providing comprehensive OpenTelemetry auto-instrumentation for LLM/GenAI applications:

- 19+ LLM providers (OpenAI, Anthropic, Google, AWS Bedrock, etc.)
- 8 multi-agent frameworks (CrewAI, LangGraph, Google ADK, AutoGen, etc.)
- 20+ MCP tools (databases, caches, vector DBs, message queues)
- Automatic cost tracking for 1,050+ models
- GPU metrics collection

- PyPI: https://pypi.org/project/genai-otel-instrument/
- License: Apache-2.0