### PR TITLE
feat: add KubeStellar Console

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -386,6 +386,7 @@ You can optional use an **Ingester**, which is a service that reads data from Ka
 Visualizing the distributed tracing data.
 
 - [Jaeger](https://github.com/jaegertracing/jaeger-ui)
+- [KubeStellar Console](https://github.com/kubestellar/console) - Open source AI-powered multi-cluster Kubernetes dashboard with OpenTelemetry support for real-time observability across hybrid edge and cloud. CNCF Sandbox project.
 - [TelemetryHub](https://telemetryhub.com/)
 - [Zipkin](https://zipkin.io)
 - [Teletrace](https://github.com/teletrace/teletrace)


### PR DESCRIPTION
## Summary

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the UI section under Components.

KubeStellar Console is an open source, AI-powered multi-cluster Kubernetes dashboard with OpenTelemetry support for real-time observability across hybrid edge and cloud environments. It is a CNCF Sandbox project (Apache 2.0).

- **Website**: https://console.kubestellar.io
- **GitHub**: https://github.com/kubestellar/console
- **CNCF Sandbox** project, Apache 2.0 license
- Supports OpenTelemetry for distributed tracing and observability across multiple Kubernetes clusters
- Provides unified dashboard view for OTel-instrumented workloads