### PR TITLE
docs: Add heimdall-mcp to GenAI / LLM Instrumentation section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -266,6 +266,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 ### GenAI / LLM Instrumentation
 - [TraceVerde (genai-otel-instrument)](https://github.com/Mandark-droid/genai_otel_instrument) - Comprehensive OpenTelemetry auto-instrumentation for LLM/GenAI applications. Zero-code setup for 19+ LLM providers, 8 multi-agent frameworks, 20+ MCP tools with automatic cost tracking for 1,050+ models and GPU metrics.
 - [Future AGI](https://github.com/future-agi/future-agi) - Open-source end-to-end LLM/agent platform with OpenTelemetry-native tracing (via traceAI), evals, simulations, gateway, and guardrails. Auto-instruments 20+ AI frameworks and LLM providers.
+- [heimdall-mcp](https://github.com/enmanuelmag/heimdall-mcp) - Transparent proxy for any MCP server that intercepts JSON-RPC messages, measures latency, and exports OpenTelemetry-native spans to any OTLP-compatible backend (Jaeger, Tempo, Grafana) without modifying the original server.
 
 ### ROS2 / Robotics
 - [ros-opentelemetry](https://github.com/szobov/ros-opentelemetry) - End‑to‑End Telemetry for Robotics ([ROS2](https://www.ros.org)) based on opentelemetry's Python and C++ client libraries.


### PR DESCRIPTION
Add `heimdall-mcp` to the Monitoring section.

Heimdall is a transparent proxy for any MCP server that intercepts JSON-RPC messages, measures latency, and stores OpenTelemetry traces in SQLite/PostgreSQL/MySQL with OTLP export to Jaeger, Tempo, and Grafana.

- Website: https://stack.cardor.dev/heimdall
- GitHub: https://github.com/enmanuelmag/heimdall-mcp
- npm: `npx @cardor/heimdall-mcp`