### PR TITLE
Add Voight to GenAI / LLM Instrumentation section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -267,6 +267,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [TraceVerde (genai-otel-instrument)](https://github.com/Mandark-droid/genai_otel_instrument) - Comprehensive OpenTelemetry auto-instrumentation for LLM/GenAI applications. Zero-code setup for 19+ LLM providers, 8 multi-agent frameworks, 20+ MCP tools with automatic cost tracking for 1,050+ models and GPU metrics.
 - [Future AGI](https://github.com/future-agi/future-agi) - Open-source end-to-end LLM/agent platform with OpenTelemetry-native tracing (via traceAI), evals, simulations, gateway, and guardrails. Auto-instruments 20+ AI frameworks and LLM providers.
 - [heimdall-mcp](https://github.com/enmanuelmag/heimdall-mcp) - Transparent proxy for any MCP server that intercepts JSON-RPC messages, measures latency, and exports OpenTelemetry-native spans to any OTLP-compatible backend (Jaeger, Tempo, Grafana) without modifying the original server.
+- [Voight](https://github.com/Voightxyz/voight-vercel-ai) - OpenTelemetry SpanExporter for the Vercel AI SDK mapping `gen_ai.*` semconv spans to a hosted dashboard. Direct OpenAI / Anthropic wrappers ship the same spans via `otel: true` with built-in dedup.
 
 ### ROS2 / Robotics
 - [ros-opentelemetry](https://github.com/szobov/ros-opentelemetry) - End‑to‑End Telemetry for Robotics ([ROS2](https://www.ros.org)) based on opentelemetry's Python and C++ client libraries.


### PR DESCRIPTION
Adds Voight to the GenAI / LLM Instrumentation section.

OpenTelemetry-native LLM observability:
- `@voightxyz/vercel-ai` — SpanExporter that consumes `gen_ai.*` semconv spans from the Vercel AI SDK (`experimental_telemetry`)
- `@voightxyz/openai` and `@voightxyz/anthropic` — direct wrappers with `otel: true` opt-in that emit `gen_ai.*` spans alongside the direct ingest
- Built-in dedup via `voight.source: 'wrapper'` attribute prevents double-counting when wrappers and exporter coexist

- Repo: https://github.com/Voightxyz/voight-vercel-ai
- Homepage: https://voight.xyz
- License: Apache 2.0