### PR TITLE
Add groundcover to Distributed Tracing Solutions / Vendors

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,6 +215,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [Sematext](https://sematext.com/)
 - [Middleware](https://middleware.io/)
 - [TraceKit](https://tracekit.dev) 
+- [groundcover](https://www.groundcover.com/)
 
 ## Terminology
 - [Components](https://www.jaegertracing.io/docs/1.30/architecture/#terminology)


### PR DESCRIPTION
Adds groundcover to the Vendors list under Distributed Tracing Solutions.

groundcover supports OpenTelemetry OTLP ingestion for traces, logs, and metrics — both OTLP/HTTP and OTLP/gRPC, including via the OpenTelemetry Collector's otlphttp exporter. Same category as the existing vendor entries (Datadog, Honeycomb, Dynatrace, New Relic, Lightstep, etc.).

Followed the section's house format: bare `- [Name](url)`, no description, appended to the end.

Disclosure: I work at groundcover.