### PR TITLE
Add MB3R Stack to Open Source tracing solutions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 - [Agent-Hypervisor](https://github.com/imran-siddique/agent-hypervisor) - Runtime supervisor for multi-agent systems with a structured event bus (40+ event types) that exports ring transitions, saga steps, and liability events as distributed traces
 - [Manifest](https://manifest.build) ([GitHub](https://github.com/mnfst/manifest)) - Open-source real-time cost observability for AI agents. OTLP-native, accepts standard OpenTelemetry signals via HTTP (JSON and Protobuf). Tracks tokens, costs, messages, and model usage. Self-hostable and privacy-focused.
 - [traceAI](https://github.com/future-agi/traceAI) - Open-source OpenTelemetry-native instrumentation framework for AI applications that auto-instruments 20+ LLM providers and agent frameworks, capturing prompts, tokens, latency, and errors with zero code changes.
+- [MB3R Stack](https://github.com/MB3R-Lab/mb3r-stack) - Open-source model-based resilience toolchain that uses OpenTelemetry trace evidence for topology discovery, virtual failure simulation, continuous resilience assessment, and pre-release risk analysis.
 ### Vendors
 
 - [Aspecto](https://www.aspecto.io)


### PR DESCRIPTION
Adds [MB3R Stack](https://github.com/MB3R-Lab/mb3r-stack) to **Distributed Tracing Solutions → Open Source**.

MB3R Stack is an open-source model-based resilience toolchain that uses OpenTelemetry trace evidence for a downstream use case beyond conventional trace visualization: automated model discovery and virtual failure analysis.

The stack combines:

* **Bering** — derives topology and rolling model artifacts from trace/OTLP evidence.
* **Sheaft** — evaluates failure scenarios over those artifacts and produces resilience posture, risk analysis, and optional release-gate decisions.

This allows distributed traces to be used not only for retrospective debugging, but also as input to continuous resilience assessment, pre-release analysis, and prioritization of live chaos experiments.

### Research evidence

The underlying model-discovery and simulation approach has been evaluated against live fault-injection experiments in two published studies:

* [Model Discovery and Graph Simulation: A Lightweight Gateway to Chaos Engineering](https://conf.researchr.org/details/icse-2026/icse-2026-nier/25/Model-Discovery-and-Graph-Simulation-A-Lightweight-Gateway-to-Chaos-Engineering) — ICSE-NIER 2026, Distinguished Paper Award; evaluated on DeathStarBench.
* [Refining Resilience Model Discovery: A Case Study on the Limited Role of Asynchronous Edges in the OpenTelemetry Demo](https://link.springer.com/chapter/10.1007/978-3-032-23304-2_24) — AINA 2026; evaluated raw OpenTelemetry trace discovery and Monte Carlo resilience simulation against live container-kill experiments on the OpenTelemetry Demo.

Disclosure: I maintain MB3R Stack and am the author of the related research.